### PR TITLE
build: sign macOS pkg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ jobs:
     working_directory: ~/project
     steps:
       - checkout
+      - run: ./scripts/macos/setup_keychain
       - run: yarn install
       - run: yarn pack:macos
       - run: yarn upload:macos

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
       }
     },
     "macos": {
-      "identifier": "com.salesforce.cli"
+      "identifier": "com.salesforce.cli",
+      "sign": "Developer ID Installer: Salesforce.com Inc"
     }
   },
   "pinnedDependencies": [

--- a/scripts/macos/setup_keychain
+++ b/scripts/macos/setup_keychain
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+echo "$P12_CERTIFICATE" | base64 --decode > /tmp/Certificate.p12
+
+set -ex
+
+# add signing cert to keychain
+OSX_KEYCHAIN=$(pwd)/sfdx.db
+export OSX_KEYCHAIN
+security -v create-keychain -p heroku "$OSX_KEYCHAIN"
+security -v unlock-keychain -p heroku "$OSX_KEYCHAIN"
+security -v import /tmp/Certificate.p12 -A -P "${SFDX_DARWIN_SIGNING_PASS}" -k "$OSX_KEYCHAIN"
+security -v unlock-keychain -p heroku "$OSX_KEYCHAIN"


### PR DESCRIPTION
~Depends on #37, re-target to `main`~

DO NOT MERGE - needs new mac cert when available

### What does this PR do?

Add pkg signing to the CI job

### What issues does this PR fix or reference?

[W-8886443](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B00000096Wk6IAE/view)
