### PR TITLE
fix: read version from package.json for promote-stable-rc

### DIFF
--- a/scripts/promote-stable-rc
+++ b/scripts/promote-stable-rc
@@ -3,7 +3,7 @@
 set -ex
 
 channel="stable-rc"
-read version <<< $(git describe --tags | tr -d "v")
+version=$(node -p -e "require('./package.json').version")
 sha=$(git rev-parse --short HEAD)
 echo "Promoting $version-$sha to channel $channel"
 yarn promote --version $version --sha $sha --channel $channel --max-age 300 --macos --win


### PR DESCRIPTION
### What does this PR do?
read version from package.json as the version tag does not yet exist

### What issues does this PR fix or reference?
@W-0000000@