### PR TITLE
chore: bump xcode for newer nodejs, set mac size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,8 +71,8 @@ jobs:
 
   pack-and-upload-macos-installer:
     macos:
-      xcode: 10.3.0
-    resource_class: xlarge
+      xcode: 12.4.0
+    resource_class: large
     working_directory: ~/project
     steps:
       - checkout
@@ -94,7 +94,7 @@ jobs:
       - run: yarn upload:win
 
 workflows:
-  version: 2.1
+  version: 2
   release:
     jobs:
       - release-management/validate-pr:


### PR DESCRIPTION
### What does this PR do?
- get mac installers (unsigned) to build by using newer xcode (which comes with newer nodejs) 
- invalid workflows version (2, not 2.1)
- mac only has medium/large (not xlarge)

### What issues does this PR fix or reference?
@W-8886443@

build step fail here:
https://app.circleci.com/pipelines/github/salesforcecli/sfdx-cli/239/workflows/928bedfc-9906-4274-8db4-7165f7ba6b8d/jobs/1033