### PR TITLE
chore: add module name to data used to run just-nuts

### DIFF
--- a/scripts/run-plugin-nuts.js
+++ b/scripts/run-plugin-nuts.js
@@ -91,6 +91,7 @@ const triggerNutsForProject = async (sfdxVersion, module, branch = 'main') => {
       'run-auto-workflows': false,
       'run-just-nuts': true,
       sfdx_version: sfdxVersion,
+      npm_module_name: module.name,
       repo_tag: module.version,
     },
   };


### PR DESCRIPTION
### What does this PR do?

Add an additional parameter to script that triggers just-nuts that passes along the npm module name, which will be used in target jobs to checkout the source branch to be used in tests. This is specifically to solve an issues with lerna repos.

### What issues does this PR fix or reference?

@W-9167855@

