### PR TITLE
Sm/pin node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
 
   pack-and-upload-tarballs: &pack-and-upload-tarballs
     docker:
-      - image: node:latest
+      - image: node:lts
     resource_class: xlarge
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
   # is minimal since the workspace is almost a GB to attach.
   test-pack-tarballs:
     docker:
-      - image: node:latest
+      - image: node:lts
     resource_class: xlarge
     steps:
       - checkout


### PR DESCRIPTION
### What does this PR do?
builds tarballs in a node:lts image.  Currently, we're shipping node v16 because build environment is node-latest.
This also explains why we were previously shipping a v15.

### What issues does this PR fix or reference?
@W-0@
link to internal slack https://salesforce-internal.slack.com/archives/C01LKDT1P6J/p1621468401013100