### PR TITLE
chore: salesforcedx install warning

### DIFF
--- a/src/hooks/verifyPluginVersion.ts
+++ b/src/hooks/verifyPluginVersion.ts
@@ -19,6 +19,13 @@ const MIN_VERSION = '45.8.0';
 const hook: Hook.PluginsPreinstall = function (options) {
   if (options.plugin && options.plugin.type === 'npm') {
     const plugin = options.plugin;
+    if (plugin.name === 'salesforcedx') {
+      this.error(
+        `The salesforcedx plugin is deprecated.
+Installing it manually via 'sfdx plugins:install salesforcedx' is no longer supported and can result in duplicate commands and outdated plugins.
+See https://github.com/forcedotcom/cli/issues/1016 for more information about this change.`
+      );
+    }
     if (FORCE_PLUGINS.includes(plugin.name) && isVersion(plugin.tag) && compareVersions(plugin.tag, MIN_VERSION) < 0) {
       this.error(
         `The ${plugin.name} plugin can only be installed using a specific version when ` +


### PR DESCRIPTION
### What does this PR do?
checks to see if people are installing salesforcedx and gives them an error message if they are (running this as a preinstall script in npm from the salesforcedx plugin didn't produce a warning).

### What issues does this PR fix or reference?
@W-9300521@