### PR TITLE
chore(latest-rc): bump to 7.111.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ jobs:
 
   promote-channels:
     docker:
-      - image: node:latest
+      - image: node:lts
     steps:
       - checkout
       - jq/install
@@ -170,7 +170,7 @@ jobs:
 
   promote-verify:
     docker:
-      - image: node:latest
+      - image: node:lts
     steps:
       - checkout
       - jq/install
@@ -228,7 +228,7 @@ jobs:
 
   run-all-nuts:
     docker:
-      - image: node:latest
+      - image: node:lts
     parameters:
       sfdx_version:
         description: By default, the latest-rc version of the standalone CLI will be installed.
@@ -268,9 +268,9 @@ workflows:
           filters:
             branches:
               ignore: main
-      - release-management/test-package:
-          name: node-latest
-          node_version: latest
+      # - release-management/test-package:
+      #     name: node-latest
+      #     node_version: latest
       - release-management/test-package:
           name: node-14
           node_version: '14'
@@ -292,7 +292,7 @@ workflows:
       - approval:
           type: approval
           requires:
-            - node-latest
+            # - node-latest
             - node-14
             - node-12
           filters:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfdx-cli",
   "description": "Salesforce CLI",
-  "version": "7.111.2",
+  "version": "7.111.3",
   "author": "Salesforce",
   "license": "BSD-3-Clause",
   "bugs": "https://github.com/forcedotcom/cli/issues",
@@ -10,7 +10,7 @@
     "sfdx": "bin/run"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=10 <16"
   },
   "files": [
     "bin",
@@ -115,7 +115,7 @@
     "@oclif/plugin-commands": "^1.3.0",
     "@oclif/plugin-help": "^3.2.2",
     "@oclif/plugin-not-found": "^1.2.4",
-    "@oclif/plugin-plugins": "^1.9.5",
+    "@oclif/plugin-plugins": "^1.10.1",
     "@oclif/plugin-update": "1.4.0-3",
     "@oclif/plugin-warn-if-update-available": "^1.7.0",
     "@oclif/plugin-which": "^1.0.3",
@@ -139,7 +139,7 @@
     "@salesforce/sfdx-trust": "^3.6.0",
     "@salesforce/ts-types": "^1.5.17",
     "debug": "^4.3.1",
-    "salesforce-alm": "52.1.6",
+    "salesforce-alm": "52.1.7",
     "salesforce-lightning-cli": "3.0.0",
     "tslib": "^2.1.0",
     "v8-compile-cache": "^2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -740,10 +740,10 @@
     fast-levenshtein "^2.0.6"
     lodash "^4.17.13"
 
-"@oclif/plugin-plugins@^1.9.5":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@oclif/plugin-plugins/-/plugin-plugins-1.10.0.tgz#9cbf5373abdd38c764273cd409518ee16ccbace3"
-  integrity sha512-lfHNiuuCrCUtH9A912T/ztxRA9lS1lCZm+gcmVWksIJG/gwKH/fMn+GdLTbRzU2k6ojtMhBblYk1RWKxUEJuzA==
+"@oclif/plugin-plugins@^1.10.1":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@oclif/plugin-plugins/-/plugin-plugins-1.10.1.tgz#13666d7c2f591a77f7a16334feee59f9eb216eb1"
+  integrity sha512-JDUA3NtOa4OlH8ofUBXQMTFlpEkSmeE9BxoQTD6+BeUvMgqFuZThENucRvCD00sywhCmDngmIYN59gKcXpGJeQ==
   dependencies:
     "@oclif/color" "^0.x"
     "@oclif/command" "^1.5.12"
@@ -8748,10 +8748,10 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-salesforce-alm@52.1.6:
-  version "52.1.6"
-  resolved "https://registry.yarnpkg.com/salesforce-alm/-/salesforce-alm-52.1.6.tgz#583fe7205c77c95781ead4911114d39977001d32"
-  integrity sha512-GZIJ7AbB6m0u3JojkLvYgTDdnS2KIGzRfgOya+WoP9HP1Ph19FwuGng+qfzMGH1HLK1SR5fWWhmaX4/c5IlqBQ==
+salesforce-alm@52.1.7:
+  version "52.1.7"
+  resolved "https://registry.yarnpkg.com/salesforce-alm/-/salesforce-alm-52.1.7.tgz#429152a46b712198631315c0700246e19f6aad02"
+  integrity sha512-SJfMtdArLuYnnsRL0T513sdp0FAxFga2JwOArt4qie19mYXh0mr5dhj99pJqI9eXH0hwFNYyRvWiFwSjoFgxrA==
   dependencies:
     "@oclif/config" "^1.14.0"
     "@oclif/errors" "^1.2.2"


### PR DESCRIPTION
### What does this PR do?
1. re-release RC for toolbelt fix
2. limit to node <16 for SDR compatibility (!)
3. bump oclif/plugin-plugins for nexus reasons

### What issues does this PR fix or reference?
