### PR TITLE
chore: update sfdx installation dir in docker slim image

### DIFF
--- a/dockerfiles/Dockerfile_slim
+++ b/dockerfiles/Dockerfile_slim
@@ -5,8 +5,8 @@ ARG DOWNLOAD_URL=https://developer.salesforce.com/media/salesforce-cli/sfdx/chan
 RUN apt-get update
 # install cli from linux tarball with bundled node
 RUN curl -s $DOWNLOAD_URL --output sfdx-linux-x64.tar.xz \
-  && mkdir ~/sfdx \
-  && tar xJf sfdx-linux-x64.tar.xz -C ~/sfdx --strip-components 1 \
+  && mkdir /usr/local/sfdx \
+  && tar xJf sfdx-linux-x64.tar.xz -C /usr/local/sfdx --strip-components 1 \
   && rm sfdx-linux-x64.tar.xz
 
 RUN apt-get install --assume-yes \
@@ -16,7 +16,7 @@ RUN apt-get autoremove --assume-yes \
   && apt-get clean --assume-yes \
   && rm -rf /var/lib/apt/lists/*
 
-ENV PATH="~/sfdx/bin:$PATH"
+ENV PATH="/usr/local/sfdx/bin:$PATH"
 ENV SFDX_CONTAINER_MODE true
 ENV DEBIAN_FRONTEND=dialog
 ENV SHELL /bin/bash

--- a/dockerfiles/Dockerfile_slim
+++ b/dockerfiles/Dockerfile_slim
@@ -5,7 +5,7 @@ ARG DOWNLOAD_URL=https://developer.salesforce.com/media/salesforce-cli/sfdx/chan
 RUN apt-get update
 # install cli from linux tarball with bundled node
 RUN curl -s $DOWNLOAD_URL --output sfdx-linux-x64.tar.xz \
-  && mkdir /usr/local/sfdx \
+  && mkdir -p /usr/local/sfdx \
   && tar xJf sfdx-linux-x64.tar.xz -C /usr/local/sfdx --strip-components 1 \
   && rm sfdx-linux-x64.tar.xz
 


### PR DESCRIPTION
### What does this PR do?
Update `sfdx` installation dir to `/usr/local/sfdx` instead of `~/sfdx` which causes errors for non-root users.

### What issues does this PR fix or reference?
Fixes: https://github.com/forcedotcom/cli/issues/1123
@W-9775541@
