### PR TITLE
chore(latest-rc): bump to 7.115.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfdx-cli",
   "description": "Salesforce CLI",
-  "version": "7.115.0",
+  "version": "7.115.1",
   "author": "Salesforce",
   "license": "BSD-3-Clause",
   "bugs": "https://github.com/forcedotcom/cli/issues",


### PR DESCRIPTION
### What does this PR do?
bump to version 7.115.1 and include the SF CLI release candidate
