### PR TITLE
fix: dont resolve sf path

### DIFF
--- a/scripts/include-sf.js
+++ b/scripts/include-sf.js
@@ -4,7 +4,7 @@ const path = require('path');
 const shelljs = require('shelljs');
 const fs = require('fs');
 
-const sfUnixPath = path.resolve('node_modules/@salesforce/cli/bin/run');
+const sfUnixPath = 'node_modules/@salesforce/cli/bin/run';
 const sfBin = path.join('bin', 'sf');
 const sfdxBin = path.join('bin', 'sfdx');
 


### PR DESCRIPTION
### What does this PR do?

- Removes the `path.resolve` when adding in the `sf` path. In CI, this was resolving to a path in the build which doesn't exist on people's machines

### What issues does this PR fix or reference?
[skip-validate-pr]