### PR TITLE
fix: add script to execute sf

### DIFF
--- a/bin/run-sf
+++ b/bin/run-sf
@@ -12,4 +12,4 @@ function trimUntil(fsPath, part) {
 
 const modulePath = require.resolve('@salesforce/cli');
 const sfPath = path.join(trimUntil(modulePath, 'cli'), 'bin', 'run');
-cp.spawn(sfPath, process.argv.slice(2), { stdio: 'inherit' });
+cp.spawn(sfPath, process.argv.slice(2), { stdio: 'inherit', shell: true });

--- a/bin/run-sf
+++ b/bin/run-sf
@@ -3,6 +3,13 @@
 const cp = require('child_process');
 const path = require('path');
 
-const sfPath = path.join('node_modules', '.bin', 'sf')
+function trimUntil(fsPath, part) {
+  const parts = fsPath.split(path.sep);
+  const partIndex = parts.findIndex((p) => part === p);
+  if (partIndex === -1) return fsPath;
+  return parts.slice(0, partIndex + 1).join(path.sep);
+}
 
-cp.spawn(sfPath, process.argv.slice(2), { stdio: 'inherit' })
+const modulePath = require.resolve('@salesforce/cli');
+const sfPath = path.join(trimUntil(modulePath, 'cli'), 'bin', 'run');
+cp.spawn(sfPath, process.argv.slice(2), { stdio: 'inherit' });

--- a/bin/run-sf
+++ b/bin/run-sf
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+const cp = require('child_process');
+const path = require('path');
+
+const sfPath = path.join('node_modules', '.bin', 'sf')
+
+cp.spawn(sfPath, process.argv.slice(2), { stdio: 'inherit' })

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "repository": "salesforcecli/sfdx-cli",
   "bin": {
     "sfdx": "bin/run",
-    "sf": "node_modules/@salesforce/cli/bin/run"
+    "sf": "bin/run-sf"
   },
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
### What does this PR do?

- Adds a script that will execute `sf`. This is preferable to specifying the node_modules sf path for the bin since we can't guarantee that node_modules will exist when npm creates the `sf` executable.
- Better handle errors during postupdate hook
- Add more information to failed sf installs from postupdate hook

#### Testing
**Local Install**
1. `mkdir test-dir && cd test-dir`
2. `npm init`
3. `npm install git+ssh://git@github.com/salesforcecli/sfdx-cli.git#mdonnalley/sf-path`

**Global Install**
1. `npm install -g git+ssh://git@github.com/salesforcecli/sfdx-cli.git#mdonnalley/sf-path`
### What issues does this PR fix or reference?
@W-9875023@
@W-9875088@
@W-9831748@
https://github.com/forcedotcom/cli/issues/1174
https://github.com/forcedotcom/cli/issues/1175