### PR TITLE
chore: suggest alternative install paths for failed sf installs

### DIFF
--- a/src/hooks/postupdate.ts
+++ b/src/hooks/postupdate.ts
@@ -9,12 +9,25 @@ import { exec, which } from 'shelljs';
 import { TelemetryGlobal } from '@salesforce/plugin-telemetry/lib/telemetryGlobal';
 import { AppInsights } from '@salesforce/telemetry/lib/appInsights';
 import { JsonMap } from '@salesforce/ts-types';
+import { cli } from 'cli-ux';
 
 declare const global: TelemetryGlobal;
 
 function sendEvent(data: JsonMap): void {
   if (global.cliTelemetry && global.cliTelemetry.record) {
     global.cliTelemetry.record(data);
+  }
+}
+
+function suggestAlternatives(): void {
+  cli.log('Failed to install sf. Try one of the following:');
+  cli.log('- npm: npm install @salesforce/cli --global');
+  if (process.platform === 'win32') {
+    cli.log('- installer: https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-x64.exe');
+  } else if (process.platform === 'darwin') {
+    cli.log('- installer: https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf.pkg');
+  } else {
+    cli.log('- download: https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-linux-x64.tar.gz');
   }
 }
 
@@ -31,6 +44,8 @@ function sendEvent(data: JsonMap): void {
 // eslint-disable-next-line @typescript-eslint/require-await
 const hook = async function (): Promise<void> {
   const sfdxVersion = exec('sfdx --version', { silent: true })?.stdout || 'unknown';
+  cli.action.start('sfdx-cli: Installing sf');
+  let succcess = false;
   try {
     const npmInstallation = which('npm')?.stdout;
     if (!npmInstallation) {
@@ -55,6 +70,7 @@ const hook = async function (): Promise<void> {
       return;
     }
 
+    succcess = true;
     const sfVersion = exec('sf --version', { silent: true }).stdout;
     sendEvent({
       eventName: 'POST_SFDX_UPDATE_SF_INSTALL_SUCCESS',
@@ -65,6 +81,7 @@ const hook = async function (): Promise<void> {
     });
   } catch (error) {
     const err = error as Error;
+    succcess = false;
     sendEvent({
       eventName: 'POST_SFDX_UPDATE_SF_INSTALL_ERROR',
       type: 'EVENT',
@@ -73,6 +90,9 @@ const hook = async function (): Promise<void> {
       sfdxVersion,
     });
     return;
+  } finally {
+    cli.action.stop(succcess ? 'done' : 'failed');
+    if (!succcess) suggestAlternatives();
   }
 };
 


### PR DESCRIPTION
### What does this PR do?

Suggest alternative ways to install `sf` if the postupdate hook fails to install it for the user

```
~/repos/salesforcecli/sfdx-cli [main] : sfdx update
sfdx-cli: Installing sf... failed
Failed to install sf. Try one of the following:
- npm: npm install @salesforce/cli --global
- installer: https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf.pkg
```

### What issues does this PR fix or reference?
@W-9916812@