### PR TITLE
fix: use absolute path to sf

### DIFF
--- a/scripts/include-sf.js
+++ b/scripts/include-sf.js
@@ -18,7 +18,7 @@ const binContents = fs
   .readFileSync(sfdxBin, 'UTF-8')
   .replace(/sfdx/g, 'sf')
   .replace(/SFDX/g, 'SF')
-  .replace(/\$DIR\/run/g, sfUnixPath);
+  .replace(/\$DIR\/run/g, `$(dirname $DIR)/${sfUnixPath}`);
 
 console.log(`  Writing ${sfBin}`);
 fs.writeFileSync(sfBin, binContents);


### PR DESCRIPTION
### What does this PR do?

Uses absolute path for `sf`

### What issues does this PR fix or reference?
[skip-validate-pr]