### PR TITLE
fix: update @salesforce/templates to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "@salesforce/plugin-schema": "1.0.8",
     "@salesforce/plugin-source": "1.1.0",
     "@salesforce/plugin-telemetry": "1.2.4",
-    "@salesforce/plugin-templates": "52.1.0",
+    "@salesforce/plugin-templates": "52.2.0",
     "@salesforce/plugin-trust": "^1.0.8",
     "@salesforce/plugin-user": "1.4.0",
     "@salesforce/require-analytics": "^0.9.16",


### PR DESCRIPTION
### What does this PR do?
Updates `@salesforce/plugin-templates` to the latest version so the `@salesforce/templates` library that it brings in won't conflict with the one included by `sf` through `@salesforce/plugin-generate`, it should be `52.2.0` in both.

### What issues does this PR fix or reference?
@W-9958398@