### PR TITLE
chore: update bug template to mention sf

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -5,10 +5,8 @@ about: Create a report to help us improve
 
 <!--
 NOTICE: While GitHub is the preferred channel for reporting issues/feedback, this is not a mechanism for receiving support under any agreement or SLA. If you require immediate assistance, please use official support channels.
--->
 
-<!--
-FOR BUGS RELATED TO THE SALEFORCE CLI, please use this repository: https://github.com/forcedotcom/cli-packages
+For issues related to the sf executable, please use https://github.com/salesforcecli/cli/issues instead.
 -->
 
 ### Summary


### PR DESCRIPTION
### What does this PR do?

Direct customers to log `sf` issues in sf repo

### What issues does this PR fix or reference?
[skip-validate-pr]