### PR TITLE
chore: use symbolic node names in circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,20 +293,20 @@ workflows:
       #     name: node-latest
       #     node_version: latest
       - release-management/test-package:
-          name: node-14
-          node_version: '14'
+          name: node-lts
+          node_version: 'lts'
       - release-management/test-package:
-          name: node-14-windows
-          node_version: '14'
+          name: node-lts-windows
+          node_version: 'lts'
           os: windows
       - release-management/test-package:
-          name: node-12
-          node_version: '12'
+          name: node-maintenance
+          node_version: 'maintenance'
       - test-pack-tarballs:
           # no point to pack if the test fail, and we only care to test the pack with the node version
           # we ship (specified in package.json.oclif.node)
           requires:
-            - node-14
+            - node-lts
           filters:
             branches:
               ignore: main # test the pack on PRs, but main will do pack-and-upload-tarballs
@@ -314,8 +314,8 @@ workflows:
           type: approval
           requires:
             # - node-latest
-            - node-14
-            - node-12
+            - node-lts
+            - node-maintenance
           filters:
             branches:
               only:


### PR DESCRIPTION
### What does this PR do?
Updates circle config to use symbolic node names (needed for nvm-windows, [we handle them for nvm-sh](https://github.com/forcedotcom/npm-release-management-orb/blob/f260b743abaac749d304a7e708d434a943ab35d5/src/commands/install-node.yml#L38)).

### What issues does this PR fix or reference?
