### PR TITLE
chore: testing slack notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ jobs:
       - slack/notify:
           channel: 'cli-team-notifications'
           color: '#9bcd9b'
-          message: 'sfdx-cli latest has been published'
+          message: '`sfdx-cli` (version X.XXX.X) has been promoted to latest. :tada2: Release notes: https://github.com/forcedotcom/cli/blob/master/releasenotes/README.md'
       - slack/status:
           channel: 'cli-team-alerts'
           fail_only: true


### PR DESCRIPTION
### What does this PR do?
adds slack notifications for `cli-team-alerts` when there is a fatal error
adds a notification to `cli-team-notification` when a successful promotion happens

### What issues does this PR fix or reference?
@W-9852060@