### PR TITLE
Add NPM_CONFIG_PREFIX to prevent mkdir permission issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,8 @@ jobs:
       - setup_remote_docker
       - run: echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
       - run: yarn promote-docker
+    environment:
+      NPM_CONFIG_PREFIX: "~/.npm-global"
 
   promote-verify:
     docker:


### PR DESCRIPTION
### What does this PR do?
The `docker-promote` step was failing after [this change](https://github.com/salesforcecli/sfdx-cli/pull/282) to how we install `sf`. The Circle provided Docker node image was throwing a permission denied error when trying to install `sf` globally ([failing build](https://app.circleci.com/pipelines/github/salesforcecli/sfdx-cli/1558/workflows/95bc15a7-52bf-459b-a19d-189b3f6c2706/jobs/6435)).

This sets the `NPM_CONFIG_PREFIX` to a path that the user has access to and now global installs work ([successful build](https://app.circleci.com/pipelines/github/salesforcecli/sfdx-cli/1568/workflows/7a14c017-960d-4215-a403-5cb73c17ae0f/jobs/6483?invite=true#step-102-16))

@W-0@
