### PR TITLE
Ignore scripts when running yarn install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,12 +192,10 @@ jobs:
       - image: cimg/node:lts
     steps:
       - checkout
-      - run: yarn install
+      - run: yarn install --ignore-scripts
       - setup_remote_docker
       - run: echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
       - run: yarn promote-docker
-    environment:
-      NPM_CONFIG_PREFIX: '~/.npm-global'
 
   promote-verify:
     docker:
@@ -215,13 +213,11 @@ jobs:
     steps:
       - checkout
       # to get shelljs
-      - run: yarn install
+      - run: yarn install --ignore-scripts
       - setup_remote_docker
       - run: echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
       - run: yarn pack:docker:slim
       - verify-slim-dependencies
-    environment:
-      NPM_CONFIG_PREFIX: '~/.npm-global'
 
   docker-publish-full:
     docker:
@@ -229,13 +225,11 @@ jobs:
     steps:
       - checkout
       # to get shelljs
-      - run: yarn install
+      - run: yarn install --ignore-scripts
       - setup_remote_docker
       - run: echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
       - run: yarn pack:docker:full
       - verify-full-dependencies
-    environment:
-      NPM_CONFIG_PREFIX: '~/.npm-global'
 
   close-CTC:
     docker:


### PR DESCRIPTION
### What does this PR do?
We had issues running docker promote build steps last release. 

The new `sf` global post install hook would cause a permission denied error. We tried to get around this by changing the `NPM_CONFIG_PREFIX` to something that the Docker user had access to but still saw issues in the `docker-publish-full` script. 

This change removes that env var and adds a `--ignore-scripts` instead. The modules needed to run the scripts will be installed and the post install hook for `sf` will be skipped. 

### What issues does this PR fix or reference?
[@W-10066269@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-10066269)