### PR TITLE
Install `sf` separately in `docker-publish-full`

### DIFF
--- a/dockerfiles/Dockerfile_full
+++ b/dockerfiles/Dockerfile_full
@@ -2,6 +2,7 @@ FROM heroku/heroku:18
 
 ENV DEBIAN_FRONTEND=noninteractive
 ARG SALESFORCE_CLI_VERSION=latest-rc
+ARG SF_CLI_VERSION=latest-rc
 
 RUN echo '4781b162129b19bdb3a7010cab12d06fc7c89421ea3fda03346ed17f09ceacd6  ./nodejs.tar.gz' > node-file-lock.sha \
   && curl -s -o nodejs.tar.gz https://nodejs.org/dist/v14.17.1/node-v14.17.1-linux-x64.tar.gz \
@@ -11,14 +12,13 @@ RUN mkdir /usr/local/lib/nodejs \
   && rm nodejs.tar.gz node-file-lock.sha
 
 ENV PATH=/usr/local/lib/nodejs/bin:$PATH
-RUN npm install --global sfdx-cli@${SALESFORCE_CLI_VERSION}
+RUN npm install --global sfdx-cli@${SALESFORCE_CLI_VERSION} --ignore-scripts
+RUN npm install --global @salesforce/cli@${SF_CLI_VERSION}
 
 RUN apt-get update && apt-get install --assume-yes openjdk-11-jdk-headless jq
 RUN apt-get autoremove --assume-yes \
   && apt-get clean --assume-yes \
   && rm -rf /var/lib/apt/lists/*
-
-
 
 ENV SFDX_CONTAINER_MODE true
 ENV DEBIAN_FRONTEND=dialog

--- a/scripts/docker-publish-full.js
+++ b/scripts/docker-publish-full.js
@@ -19,9 +19,15 @@ const DOCKER_HUB_REPOSITORY = dockerShared.repo;
 (async () => {
   dockerShared.validateDockerEnv();
   const SALESFORCE_CLI_VERSION = await dockerShared.getCliVersion();
+  const SF_CLI_VERSION = process.env.SF_CLI_VERSION ?? 'latest-rc';
 
   shell.exec(
-    `docker build --file ./dockerfiles/Dockerfile_full --build-arg SALESFORCE_CLI_VERSION=${SALESFORCE_CLI_VERSION} --tag ${DOCKER_HUB_REPOSITORY}:${SALESFORCE_CLI_VERSION}-full --no-cache .`
+    `docker build \
+      --file ./dockerfiles/Dockerfile_full \
+      --build-arg SALESFORCE_CLI_VERSION=${SALESFORCE_CLI_VERSION} \
+      --build-arg SF_CLI_VERSION=${SF_CLI_VERSION} \
+      --tag ${DOCKER_HUB_REPOSITORY}:${SALESFORCE_CLI_VERSION}-full \
+      --no-cache .`
   );
 
   if (process.env.NO_PUBLISH) return;


### PR DESCRIPTION
### What does this PR do?
This fixes `sf` installs in the `docker-publish-full` build step. Since `sf` was changed to install via an npm postinstall script, we have been seeing [permission denied errors](https://app.circleci.com/pipelines/github/salesforcecli/sfdx-cli/1621/workflows/0c30d5a5-2bfa-40b4-aa33-9fe0bf1b6c98/jobs/6639) in CI. This appears to be an issue with the "nested" npm installs when running as `root` on linux ([here is another instance](https://github.com/microsoft/appcenter-cli/issues/1007#issuecomment-668316092)). Instead of installing `sf` in a postinstall script, we ignore scripts on the `sfdx` install and install `sf` separately. This has the added benefit of letting us override the version of `sf` if needed. 

### Testing Instructions
- Pull branch
- Make sure Docker is running locally
- Comment out [this line](https://github.com/salesforcecli/sfdx-cli/blob/52ba0c8a5ec917166b072d6904196ccce40bda48/scripts/docker-publish-full.js#L20) (skips login validation)
-  Run `NO_PUBLISH=true SF_CLI_VERSION=latest yarn pack:docker:full`
    - **NOTE:** We pass `latest` here because `sf` does not have a `latest-rc` tag yet. It will soon. In the meantime, we can set `SF_CLI_VERSION=latest` in CircleCi for this to build successfully. As soon as a `latest-rc` is published, this env var could be removed from Circle 
- After it builds click on `Images` in the Docker UI
- Find `salesforce/salesforcedx` and click `Run`
- Click on the CLI icon to exec into the container
- Confirm `sf` and `sfdx` exist

### What issues does this PR fix or reference?
[@W-10066269@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-10066269)