### PR TITLE
chore: update path to sf on windows

### DIFF
--- a/scripts/include-sf.js
+++ b/scripts/include-sf.js
@@ -26,7 +26,7 @@ console.log(`  Writing ${sfBin}`);
 fs.writeFileSync(sfBin, binContents);
 shelljs.chmod('+x', sfBin);
 
-const sfWinPath = 'sf-cli\\bin\\run.cmd';
+const sfWinPath = 'sf-cli\\bin\\run';
 const sfCmd = path.join('bin', 'sf.cmd');
 const sfdxCmd = path.join('bin', 'sfdx.cmd');
 


### PR DESCRIPTION
### What does this PR do?

Use the correct path for `sf` for windows

### What issues does this PR fix or reference?
[skip-validate-pr]