### PR TITLE
Fix postupdate hook to install `sf`

### DIFF
--- a/src/hooks/postupdate.ts
+++ b/src/hooks/postupdate.ts
@@ -39,7 +39,7 @@ function suggestAlternatives(): void {
 function isNpmInstall(sfPath: string): boolean {
   const nodePathParts = ['node', 'nodejs', '.nvm', '.asdf', 'node_modules', 'npm', '.npm'];
   const sfPathParts = sfPath.split(path.sep);
-  return sfPathParts.filter((p) => nodePathParts.includes(p)).length > 0;
+  return sfPathParts.filter((p) => nodePathParts.includes(p.toLowerCase())).length > 0;
 }
 
 /**


### PR DESCRIPTION
### What does this PR do?
Fixes the function that checks if `sf` is an npm install so that it is case insensitive.

### What issues does this PR fix or reference?
@W-0@