### PR TITLE
chore: remove postinstall of @salesforce/cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,7 +217,6 @@
     "pack:tarballs": "oclif pack:tarballs",
     "pack:verify": "sf-release cli:tarballs:verify",
     "pack:win": "oclif pack:win --additional-cli sf",
-    "postinstall": "npm install @salesforce/cli -g",
     "postpack": "shx rm -f oclif.manifest.json",
     "posttest": "yarn test:deprecation-policy ",
     "prepack": "yarn compile && yarn lint && yarn oclif-artifacts",


### PR DESCRIPTION
### What does this PR do?

Removes the `postinstall` script so that `@salesforce/cli` is no longer install with sfdx (npm installs only)

### What issues does this PR fix or reference?
@W-10121246@
https://github.com/forcedotcom/cli/issues/1286