### PR TITLE
chore: run sf-install on local install

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
     "postpack": "shx rm -f oclif.manifest.json",
     "posttest": "yarn test:deprecation-policy ",
     "prepack": "yarn compile && yarn lint && yarn oclif-artifacts",
-    "prepare": "yarn compile && yarn lint",
+    "prepare": "sf-install && yarn compile && yarn lint",
     "pretarball": "sf-release cli:tarballs:prepare && ./scripts/include-sf.js",
     "promote-dist-tags": "./scripts/promote-dist-tags",
     "promote-docker": "./scripts/docker-promote.js",


### PR DESCRIPTION
### What does this PR do?
Updates `prepare` script to make sure `sf-install` runs on local npm/yarn install.

### What issues does this PR fix or reference?
@W-10088025@
