### PR TITLE
chore: bump macos image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
 
   pack-and-upload-macos-installer:
     macos:
-      xcode: 12.5.1
+      xcode: 13.2.1
     steps:
       - checkout
       - run: git fetch origin && git pull


### PR DESCRIPTION
### What does this PR do?
Bumps macos image so that our macos `.pkg` gets latest node LTS.

CircleCI docs:
https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions

### What issues does this PR fix or reference?
@W-8776236@