### PR TITLE
fix: no process.exit(0)

### DIFF
--- a/src/hooks/displayReleaseNotes.ts
+++ b/src/hooks/displayReleaseNotes.ts
@@ -10,14 +10,10 @@ import { spawn } from 'child_process';
 import { Hook } from '@oclif/config';
 import { cli } from 'cli-ux';
 
-if (process.env.SFDX_HIDE_RELEASE_NOTES === 'true') process.exit(0);
-
-const logAndExit = (msg: Error): void => {
+const logError = (msg: Error): void => {
   cli.log('NOTE: This error can be ignored in CI and may be silenced in the future');
   cli.log('- Set the SFDX_HIDE_RELEASE_NOTES env var to "true" to skip this script\n');
   cli.log(msg.toString());
-
-  process.exit(0);
 };
 
 /*
@@ -25,27 +21,38 @@ const logAndExit = (msg: Error): void => {
  * https://github.com/salesforcecli/sfdx-cli/pull/407
  */
 
-const hook: Hook.Update = () => {
-  // NOTE: This is `sfdx.cmd` here and not `run.cmd` because it gets renamed here:
-  // https://github.com/salesforcecli/sfdx-cli/blob/4428505ab69aa6e21214dba96557e2ce396a82e0/src/hooks/postupdate.ts#L62
-  const executable = process.platform === 'win32' ? 'sfdx.cmd' : 'run';
+const hook: Hook.Update = async (): Promise<void> => {
+  return new Promise((resolve) => {
+    if (process.env.SFDX_HIDE_RELEASE_NOTES === 'true') {
+      resolve();
+    }
 
-  const cmd = spawn(join(__dirname, '..', '..', 'bin', executable), ['whatsnew', '--hook'], {
-    stdio: ['ignore', 'inherit', 'pipe'],
-    timeout: 10000,
-  });
+    // NOTE: This is `sfdx.cmd` here and not `run.cmd` because it gets renamed here:
+    // https://github.com/salesforcecli/sfdx-cli/blob/4428505ab69aa6e21214dba96557e2ce396a82e0/src/hooks/postupdate.ts#L62
+    const executable = process.platform === 'win32' ? 'sfdx.cmd' : 'run';
+    const cmd = spawn(join(__dirname, '..', '..', 'bin', executable), ['whatsnew', '--hook'], {
+      stdio: ['ignore', 'inherit', 'pipe'],
+      timeout: 10000,
+    });
 
-  cmd.stderr.on('data', (error: Error) => {
-    logAndExit(error);
-  });
+    cmd.stderr.on('data', (error: Error) => {
+      logError(error);
+      resolve();
+    });
 
-  cmd.on('error', (error: Error) => {
-    logAndExit(error);
-  });
+    cmd.on('error', (error: Error) => {
+      logError(error);
+      resolve();
+    });
 
-  // 'exit' fires whether or not the stream are finished
-  cmd.on('exit', () => {
-    process.exit(0);
+    // 'exit' fires whether or not the stream are finished
+    cmd.on('exit', () => {
+      resolve();
+    });
+
+    cmd.on('close', () => {
+      resolve();
+    });
   });
 };
 


### PR DESCRIPTION
### What does this PR do?
there's 2 ways into this script
- oclif hook (for `sfdx update`) **changed**
- [npm script](https://github.com/salesforcecli/sfdx-cli/blob/main/scripts/post-install-release-notes.js) (for `npm install -g`) **is unmodified**

This modifies the oclif hook to return a promise, and to `resolve()` on all errors instead of `exit(0)`
The npm script still uses exit(0) because it's not part of the hooks stuff and really is a process that can exit. 

QA: I "released" this on the `dev` sfdx-cli channel (for both installer and npm).  There is no release notes entry for `7.134.0-dev.0` so you *should* get an error logged in the terminal but not an *actual* throw/exit

I tested on installer on mac.  

### What issues does this PR fix or reference?
@W-10419173@
