### PR TITLE
feat: warn people about salesforcedx during update

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
       "update": [
         "./dist/hooks/lazyRequire.js",
         "./dist/hooks/postupdate.js",
-        "./dist/hooks/displayReleaseNotes.js"
+        "./dist/hooks/displayReleaseNotes.js",
+        "./dist/hooks/salesforcedx-check.js"
       ]
     },
     "plugins": [

--- a/scripts/checkSalesforceDx.ts
+++ b/scripts/checkSalesforceDx.ts
@@ -1,0 +1,3 @@
+import dxCheck from '../dist/hooks/salesforcedx-check.js';
+
+dxCheck();

--- a/src/hooks/salesforcedx-check.ts
+++ b/src/hooks/salesforcedx-check.ts
@@ -11,8 +11,8 @@ import { AnyJson, get } from '@salesforce/ts-types';
 import { cli } from 'cli-ux';
 import { compareVersions } from '../versions';
 
-const salesforcedxError = `The salesforcedx plugin is deprecated.  Using it results in very old versions of commands running.
-    Uninstall it with 'sfdx plugins:uninstall salesforcedx'.
+const salesforcedxError = `You still have the deprecated salesforcedx plugin installed in Salesforce CLI. If you continue using this plugin, you'll be running old and out-of-date versions of sfdx commands.
+    Uninstall the plugin with this command: 'sfdx plugins:uninstall salesforcedx'.
     See https://github.com/forcedotcom/cli/blob/main/releasenotes/sfdx/README.md#71063-june-17-2021 for more information about this change.`;
 
 const MAX_VERSION = '7.107.0';

--- a/src/hooks/salesforcedx-check.ts
+++ b/src/hooks/salesforcedx-check.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import * as path from 'path';
+import Plugins from '@oclif/plugin-plugins';
+import { Config } from '@oclif/config';
+import { AnyJson, get } from '@salesforce/ts-types';
+import { cli } from 'cli-ux';
+import { compareVersions } from '../versions';
+
+const salesforcedxError = `The salesforcedx plugin is deprecated.  Using it results in very old versions of commands running.
+    Uninstall it with 'sfdx plugins:uninstall salesforcedx'.
+    See https://github.com/forcedotcom/cli/blob/main/releasenotes/sfdx/README.md#71063-june-17-2021 for more information about this change.`;
+
+const MAX_VERSION = '7.107.0';
+
+const hook = async (): Promise<void> => {
+  // PART 1: is the CLI recent enough that we don't allow salesforcedx?
+  const root = path.resolve(__dirname, '..', '..');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const pjson = require(path.resolve(root, 'package.json')) as AnyJson;
+  const config = new Config({ name: get(pjson, 'oclif.bin') as string | undefined, root });
+  await config.load();
+
+  // early exit for old CLIs that shouldn't bother inspecting their plugins
+  if (compareVersions(config.version, MAX_VERSION) < 0) {
+    return;
+  }
+
+  // PART 2: is the salesforcedx plugin installed?
+  const plugins = new Plugins(config);
+
+  const installedUserPlugins = (await plugins.list())
+    .filter((plugin) => plugin.type === 'user')
+    .map((plugin) => plugin.name);
+  cli.log(`user plugins are ${installedUserPlugins.join(', ')}`);
+
+  if (installedUserPlugins.includes('salesforcedx')) {
+    cli.warn(salesforcedxError);
+  }
+};
+
+export default hook;


### PR DESCRIPTION
### What does this PR do?
warns people when they have a CLI > 7.107 and are running salesforcedx as a user plugin

### What issues does this PR fix or reference?
@W-10260547@

Testing is hard since we block the installation of the evil plugin. `Update` hook only makes sense for installer based CLIs.

1. install the evil plugin
    1. find your installed directory.  Mine was `~./.local/share/sfdx/client/current` which is a shortcut to an actual version.  There's a version your last few CLIs.  We'll refer to this as `CurrentCLI`
    1. in that repo, under `dist/hooks/verifyPluginVersion` you can remove salesforcedx from the BANNED_PLUGINS array
    1. now, `sfdx plugins:install salesforcedx`
1. OPTION 1: In the sfdx-cli repo that you're QAing, execute the script directly via a new TS file in /scripts
    1. `import dxCheck from  '../dist/hooks/salesforcedx-check.js'; dxCheck();`
    2. yarn ts-node `whatever you saved the file as.ts`
1. OPTION 2: as part of an update
    1. run `sfdx update stable` to get on a known channel.
    1.  Back in `CurrentCLI` copy the 2 changes from this branch (the hooks entry in package.json AND the dist/src/hooks/salesforcedx-check.js (yarn build sfdx-cli if you haven't already so that js file appears)
    2. now you can update to some other version.  When you update back to whatever `CurrentCLI` points to, you'll see the warning again
    3. you can repeat the steps from 1 across your other plugin and then you'd see it on both `update` operations.

Don't forget to uninstall the evil plugin or you'll have a bad day and not known why.
