### PR TITLE
chore: use node lts in docker-full

### DIFF
--- a/dockerfiles/Dockerfile_full
+++ b/dockerfiles/Dockerfile_full
@@ -4,8 +4,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 ARG SALESFORCE_CLI_VERSION=latest-rc
 ARG SF_CLI_VERSION=latest-rc
 
-RUN echo '4781b162129b19bdb3a7010cab12d06fc7c89421ea3fda03346ed17f09ceacd6  ./nodejs.tar.gz' > node-file-lock.sha \
-  && curl -s -o nodejs.tar.gz https://nodejs.org/dist/v14.17.1/node-v14.17.1-linux-x64.tar.gz \
+RUN echo 'a0f23911d5d9c371e95ad19e4e538d19bffc0965700f187840eb39a91b0c3fb0  ./nodejs.tar.gz' > node-file-lock.sha \
+  && curl -s -o nodejs.tar.gz https://nodejs.org/dist/v16.13.2/node-v16.13.2-linux-x64.tar.gz \
   && shasum --check node-file-lock.sha
 RUN mkdir /usr/local/lib/nodejs \
   && tar xf nodejs.tar.gz -C /usr/local/lib/nodejs/ --strip-components 1 \


### PR DESCRIPTION
### What does this PR do?
docker full uses node lts

### What issues does this PR fix or reference?
@W-10289832@