### PR TITLE
chore: revert promote-to-latest cron

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,7 +400,7 @@ workflows:
     triggers:
       - schedule:
           # Thursday mornings at 10am mountain
-          cron: '00 23 * * 5'
+          cron: '00 16 * * 4'
           filters:
             branches:
               only:


### PR DESCRIPTION
### What does this PR do?

Reverts promote-to-latest cron back to `00 16 * * 4`