### PR TITLE
fix: update install links for mac pkg

### DIFF
--- a/src/hooks/postupdate.ts
+++ b/src/hooks/postupdate.ts
@@ -32,7 +32,11 @@ function suggestAlternatives(): void {
   if (process.platform === 'win32') {
     CliUx.ux.log('- installer: https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-x64.exe');
   } else if (process.platform === 'darwin') {
-    CliUx.ux.log('- installer: https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf.pkg');
+    if (process.arch === 'arm64') {
+      CliUx.ux.log('- installer: https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-arm64.pkg');
+    } else {
+      CliUx.ux.log('- installer: https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-x64.pkg');
+    }
   } else {
     CliUx.ux.log(
       '- download: https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-linux-x64.tar.gz'


### PR DESCRIPTION
# DO NOT MERGE BEFORE https://github.com/oclif/oclif/pull/849

### What does this PR do?
Updates the install link for Mac pkgs in the postupdate hook to what they will be after https://github.com/oclif/oclif/pull/849 is merged.

### What issues does this PR fix or reference?
@W-10844187@