### PR TITLE
chore: remove telemetry resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,7 +202,6 @@
     "typescript": "^4.1.3"
   },
   "resolutions": {
-    "@salesforce/plugin-telemetry": "1.4.0",
     "@salesforce/source-deploy-retrieve": "5.12.8",
     "@salesforce/source-tracking": "1.3.1",
     "@salesforce/templates": "54.3.0",


### PR DESCRIPTION
### What does this PR do?
remove telemetry resolution

this was useful when toolbelt was doing direct access to telemetry but it's not anymore