### PR TITLE
chore: use release context for dependabot-automerge [skip ci]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -479,4 +479,5 @@ workflows:
               only:
                 - main
     jobs:
-      - release-management/dependabot-automerge
+      - release-management/dependabot-automerge:
+          context: release


### PR DESCRIPTION
[skip-validate-pr]