### PR TITLE
Add schemas to yarn resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,6 +205,7 @@
     "typescript": "^4.1.3"
   },
   "resolutions": {
+    "@salesforce/schemas": "1.1.0",
     "@salesforce/source-deploy-retrieve": "5.12.11",
     "@salesforce/source-tracking": "1.3.1",
     "@salesforce/templates": "54.3.0",


### PR DESCRIPTION
### What does this PR do?
Adds `@salesforce/schemas` to yarn resolutions so that we always get the newest version

These resolutions get bumped automatically in [plugin-release-management](https://github.com/salesforcecli/plugin-release-management/blob/main/src/commands/cli/latestrc/build.ts#L68)

### What issues does this PR fix or reference?
[W-11048751](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-11048751)