### PR TITLE
test: remove resolutions to help parking-orbit

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,8 +206,6 @@
   },
   "resolutions": {
     "@salesforce/schemas": "1.1.0",
-    "@salesforce/source-deploy-retrieve": "5.14.0",
-    "@salesforce/source-tracking": "1.5.0",
     "@salesforce/templates": "54.7.0",
     "@salesforce/ts-types": "1.5.20"
   },


### PR DESCRIPTION
### What does this PR do?
tests that we can remove SDR/STL resolutions

### why
current rc-build is gonna bump everything in `resolutsions` to its latest.  We want plugins to selectively be able to update to new SDR/STL major versions.

If this passes (can build tarballs that don't have length problems) I'll move it out of draft.

### What issues does this PR fix or reference?
[@W-10743680@](https://gus.lightning.force.com/a07EE00000rPGopYAG)
