### PR TITLE
chore: fix: replace old cli-ux imports

### DIFF
--- a/src/hooks/displayReleaseNotes.ts
+++ b/src/hooks/displayReleaseNotes.ts
@@ -7,13 +7,12 @@
 
 import { join } from 'path';
 import { spawn } from 'child_process';
-import { Hook } from '@oclif/core';
-import { cli } from 'cli-ux';
+import { Hook, CliUx } from '@oclif/core';
 
 const logError = (msg: Error): void => {
-  cli.log('NOTE: This error can be ignored in CI and may be silenced in the future');
-  cli.log('- Set the SFDX_HIDE_RELEASE_NOTES env var to "true" to skip this script\n');
-  cli.log(msg.toString());
+  CliUx.ux.log('NOTE: This error can be ignored in CI and may be silenced in the future');
+  CliUx.ux.log('- Set the SFDX_HIDE_RELEASE_NOTES env var to "true" to skip this script\n');
+  CliUx.ux.log(msg.toString());
 };
 
 /*

--- a/src/hooks/postupdate.ts
+++ b/src/hooks/postupdate.ts
@@ -8,7 +8,7 @@
 import * as os from 'os';
 import * as path from 'path';
 
-import { cli } from 'cli-ux';
+import { CliUx } from '@oclif/core';
 import { readFileSync, readJsonSync, writeFileSync } from 'fs-extra';
 import { chmod } from 'shelljs';
 
@@ -26,16 +26,18 @@ function sendEvent(data: JsonMap): void {
 }
 
 function suggestAlternatives(): void {
-  cli.log('Failed to update sf. Try uninstalling the CLI and re-installing it.');
-  cli.log(
+  CliUx.ux.log('Failed to update sf. Try uninstalling the CLI and re-installing it.');
+  CliUx.ux.log(
     'Uninstall instructions: https://developer.salesforce.com/docs/atlas.en-us.234.0.sfdx_setup.meta/sfdx_setup/sfdx_setup_uninstall.htm'
   );
   if (process.platform === 'win32') {
-    cli.log('- installer: https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-x64.exe');
+    CliUx.ux.log('- installer: https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-x64.exe');
   } else if (process.platform === 'darwin') {
-    cli.log('- installer: https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf.pkg');
+    CliUx.ux.log('- installer: https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf.pkg');
   } else {
-    cli.log('- download: https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-linux-x64.tar.gz');
+    CliUx.ux.log(
+      '- download: https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-linux-x64.tar.gz'
+    );
   }
 }
 
@@ -48,7 +50,7 @@ function suggestAlternatives(): void {
 const hook: Hook.Update = async function (opts): Promise<void> {
   let success = false;
 
-  cli.action.start('sfdx-cli: Updating sf');
+  CliUx.ux.action.start('sfdx-cli: Updating sf');
 
   try {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -84,7 +86,7 @@ const hook: Hook.Update = async function (opts): Promise<void> {
     });
     return;
   } finally {
-    cli.action.stop(success ? 'done' : 'failed');
+    CliUx.ux.action.stop(success ? 'done' : 'failed');
     if (!success) suggestAlternatives();
   }
 };

--- a/src/hooks/salesforcedx-check.ts
+++ b/src/hooks/salesforcedx-check.ts
@@ -6,9 +6,8 @@
  */
 import * as path from 'path';
 import Plugins from '@oclif/plugin-plugins';
-import { Config } from '@oclif/core';
+import { Config, CliUx } from '@oclif/core';
 import { AnyJson, get } from '@salesforce/ts-types';
-import { cli } from 'cli-ux';
 import { compareVersions } from '../versions';
 
 const salesforcedxError = `You still have the deprecated salesforcedx plugin installed in Salesforce CLI. If you continue using this plugin, you'll be running old and out-of-date versions of sfdx commands.
@@ -36,10 +35,10 @@ const hook = async (): Promise<void> => {
   const installedUserPlugins = (await plugins.list())
     .filter((plugin) => plugin.type === 'user')
     .map((plugin) => plugin.name);
-  cli.log(`user plugins are ${installedUserPlugins.join(', ')}`);
+  CliUx.ux.log(`user plugins are ${installedUserPlugins.join(', ')}`);
 
   if (installedUserPlugins.includes('salesforcedx')) {
-    cli.warn(salesforcedxError);
+    CliUx.ux.warn(salesforcedxError);
   }
 };
 

--- a/src/versions.js
+++ b/src/versions.js
@@ -22,7 +22,8 @@ export function isVersion(tag) {
     return false;
   }
   // From https://github.com/sindresorhus/semver-regex
-  const SEMVER_REGEX = /^v?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-z-]+(?:\.[\da-z-]+)*)?(?:\+[\da-z-]+(?:\.[\da-z-]+)*)?$/gi;
+  const SEMVER_REGEX =
+    /^v?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-z-]+(?:\.[\da-z-]+)*)?(?:\+[\da-z-]+(?:\.[\da-z-]+)*)?$/gi;
   return SEMVER_REGEX.test(tag.toString());
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -836,7 +836,7 @@
     is-wsl "^2.1.1"
     tslib "^2.3.1"
 
-"@oclif/core@^1.0.8", "@oclif/core@^1.1.1", "@oclif/core@^1.12.0", "@oclif/core@^1.13.1", "@oclif/core@^1.13.3", "@oclif/core@^1.2.0", "@oclif/core@^1.2.1", "@oclif/core@^1.3.0", "@oclif/core@^1.3.1", "@oclif/core@^1.3.4", "@oclif/core@^1.3.6", "@oclif/core@^1.5.2", "@oclif/core@^1.6.3", "@oclif/core@^1.6.4", "@oclif/core@^1.7.0", "@oclif/core@^1.8.0", "@oclif/core@^1.9.0", "@oclif/core@^1.9.2", "@oclif/core@^1.9.3", "@oclif/core@^1.9.5":
+"@oclif/core@^1.0.8", "@oclif/core@^1.1.1", "@oclif/core@^1.12.0", "@oclif/core@^1.13.3", "@oclif/core@^1.2.0", "@oclif/core@^1.2.1", "@oclif/core@^1.3.0", "@oclif/core@^1.3.1", "@oclif/core@^1.3.4", "@oclif/core@^1.3.6", "@oclif/core@^1.5.2", "@oclif/core@^1.6.3", "@oclif/core@^1.6.4", "@oclif/core@^1.7.0", "@oclif/core@^1.8.0", "@oclif/core@^1.9.0", "@oclif/core@^1.9.2", "@oclif/core@^1.9.3", "@oclif/core@^1.9.5":
   version "1.13.9"
   resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.13.9.tgz#9e359c5fd93adcd10f45daf9dda2358e598fafe4"
   integrity sha512-Ti82naHb8TpkMUX7WEiA9Ee0DmuMnm1WWm6L5CAIhbwFL8aysh6LyKIDfelDVN7xfVUJhYYB3ZqjzLmyt2eysw==


### PR DESCRIPTION
### What does this PR do?
replace old cli-ux imports with oclif/core.

We don't ship `cli-ux` with the CLI since 7.136.0 
![Screen Shot 2022-08-10 at 15 14 30](https://user-images.githubusercontent.com/6853656/183986508-8b328766-e44d-4a0b-a9f2-8e9e85c2f14e.png)


### What issues does this PR fix or reference?
@W-0@