### PR TITLE
fix: exit process if `verify:signature` hook fails

### DIFF
--- a/src/hooks/pluginsPreinstall.ts
+++ b/src/hooks/pluginsPreinstall.ts
@@ -5,12 +5,20 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Hook } from '@oclif/core';
+import { Hook, Errors } from '@oclif/core';
 
 const hook: Hook.PluginsPreinstall = async function (options) {
   // Run individual hooks serially since oclif runs hooks in parallel, which causes UX problems in this case
   await this.config.runHook('plugins:preinstall:verify:version', options);
-  await this.config.runHook('plugins:preinstall:verify:signature', options);
+
+  const verifySignHookResult = await this.config.runHook('plugins:preinstall:verify:signature', options);
+  const pluginTrustFailure = verifySignHookResult.failures.find(
+    (failure) => failure.plugin.name === '@salesforce/plugin-trust'
+  );
+
+  if (pluginTrustFailure !== undefined) {
+    Errors.handle(pluginTrustFailure.error);
+  }
 };
 
 export default hook;


### PR DESCRIPTION
### What does this PR do?
**depends on:**: https://github.com/salesforcecli/plugin-trust/pull/306

Makes `sfdx` exit the node process if the `plugins:preinstall:verify:signature` hook fails.

this hook (defined in plugin-trust) ask the user if wants to uninstall an unsigned plugin, if the user doesn't answer `y` in the prompt then the hook throws an error but `sfdx` didn't check for this so even answering `n` will make `plugin-plugins` continue installing an unsigned plugin.

`this.error`
https://github.com/salesforcecli/plugin-trust/blob/d3004720a51b4bef6ecd373f947d35c48f701fa9/src/hooks/verifyInstallSignature.ts#L74

prompt answer check:
https://github.com/salesforcecli/plugin-trust/blob/d3004720a51b4bef6ecd373f947d35c48f701fa9/src/shared/installationVerification.ts#L481

![Screen Shot 2022-09-14 at 18 43 16](https://user-images.githubusercontent.com/6853656/190268106-a7485e80-5a54-47ff-b2f3-9fd61813d0c9.png)

### What issues does this PR fix or reference?
@W-0@ 
