### PR TITLE
fix: bump dockerfile base image to heroku:20 

### DIFF
--- a/dockerfiles/Dockerfile_full
+++ b/dockerfiles/Dockerfile_full
@@ -1,4 +1,4 @@
-FROM heroku/heroku:18
+FROM heroku/heroku:20
 
 ENV DEBIAN_FRONTEND=noninteractive
 ARG SALESFORCE_CLI_VERSION=latest-rc

--- a/dockerfiles/Dockerfile_full
+++ b/dockerfiles/Dockerfile_full
@@ -4,8 +4,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 ARG SALESFORCE_CLI_VERSION=latest-rc
 ARG SF_CLI_VERSION=latest-rc
 
-RUN echo 'a0f23911d5d9c371e95ad19e4e538d19bffc0965700f187840eb39a91b0c3fb0  ./nodejs.tar.gz' > node-file-lock.sha \
-  && curl -s -o nodejs.tar.gz https://nodejs.org/dist/v16.13.2/node-v16.13.2-linux-x64.tar.gz \
+RUN echo 'da5658693243b3ecf6a4cba6751a71df1eb9e9703ca93b42a9404aed85f58ad0  ./nodejs.tar.gz' > node-file-lock.sha \
+  && curl -s -o nodejs.tar.gz https://nodejs.org/dist/v16.17.1/node-v16.17.1-linux-x64.tar.gz \
   && shasum --check node-file-lock.sha
 RUN mkdir /usr/local/lib/nodejs \
   && tar xf nodejs.tar.gz -C /usr/local/lib/nodejs/ --strip-components 1 \

--- a/dockerfiles/Dockerfile_slim
+++ b/dockerfiles/Dockerfile_slim
@@ -1,4 +1,4 @@
-FROM heroku/heroku:18
+FROM heroku/heroku:20
 
 ENV DEBIAN_FRONTEND=noninteractive
 ARG DOWNLOAD_URL=https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable-rc/sfdx-linux-x64.tar.xz


### PR DESCRIPTION
### What does this PR do?

Upgrade dockerfile base image from `heroku/heroku:18` to `heroku/heroku:20` to support use of docker container `salesforce/salesforcedx` in GitHub workflows.

```yaml
runs-on: ubuntu-latest
container: salesforce/salesforcedx:latest-rc-full
```

### What issues does this PR fix or reference?

Upgrade the `git` command from version `2.17.1` (bionic) to `2.25.1` (focal) to fix the following error using the GitHub action `actions/checkout`.

```
The repository will be downloaded using the GitHub REST API
To create a local Git repository instead, add Git 2.18 or higher to the PATH
```

