### PR TITLE
chore: specify node version for promote to latest GHA

### DIFF
--- a/.github/workflows/promoteRCtoLatest.yml
+++ b/.github/workflows/promoteRCtoLatest.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: latest
+          node-version: lts/*
           cache: yarn
       - uses: salesforcecli/github-workflows/.github/actions/versionInfo@main
         id: version-info

--- a/.github/workflows/promoteRCtoLatest.yml
+++ b/.github/workflows/promoteRCtoLatest.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+        with:
+          node-version: latest
+          cache: yarn
       - uses: salesforcecli/github-workflows/.github/actions/versionInfo@main
         id: version-info
         with:


### PR DESCRIPTION
### What does this PR do?
specifies node version with `promote-to-latest` GHA
### What issues does this PR fix or reference?
[skip-validate-pr]