### PR TITLE
chore(docker): bump node to v18

### DIFF
--- a/dockerfiles/Dockerfile_full
+++ b/dockerfiles/Dockerfile_full
@@ -4,8 +4,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 ARG SALESFORCE_CLI_VERSION=latest-rc
 ARG SF_CLI_VERSION=latest-rc
 
-RUN echo 'da5658693243b3ecf6a4cba6751a71df1eb9e9703ca93b42a9404aed85f58ad0  ./nodejs.tar.gz' > node-file-lock.sha \
-  && curl -s -o nodejs.tar.gz https://nodejs.org/dist/v16.17.1/node-v16.17.1-linux-x64.tar.gz \
+RUN echo '0699c8e02581a9c312d7157331561d36ef23963766eb47daa702edb6fd6735bd  ./nodejs.tar.gz' > node-file-lock.sha \
+  && curl -s -o nodejs.tar.gz https://nodejs.org/dist/v18.12.0/node-v18.12.0-linux-x64.tar.gz \
   && shasum --check node-file-lock.sha
 RUN mkdir /usr/local/lib/nodejs \
   && tar xf nodejs.tar.gz -C /usr/local/lib/nodejs/ --strip-components 1 \


### PR DESCRIPTION
### What does this PR do?
Updates docker image to use latest node LTS v18.

### What issues does this PR fix or reference?
@W-11955035@