### PR TITLE
Pin plugin-trust [skip ci]

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "@salesforce/plugin-schema",
     "@salesforce/plugin-telemetry",
     "@salesforce/plugin-templates",
+    "@salesforce/plugin-trust",
     "@salesforce/plugin-user",
     "@salesforce/plugin-signups",
     "@salesforce/sfdx-plugin-lwc-test",


### PR DESCRIPTION
### What does this PR do?
Pins `plugin-trust` so that it will get bumped weekly on `rc` build

### What issues does this PR fix or reference?
https://salesforce-internal.slack.com/archives/G02K6C90RBJ/p1668527319504199?thread_ts=1665591711.286379&cid=G02K6C90RBJ
@W-00000000