### PR TITLE
chore: add --debug-filter and remove ts-lint/es-lint rules where no longer required

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
 
-/* tslint:disable:no-var-requires only-arrow-functions */
-/* eslint-disable global-require, prefer-arrow-callback */
-
 // Since the CLI is a single process, we can have a larger amount of max listeners since
 // the process gets shut down. Don't set it to 0 (no limit) since we should still be aware
 // of rouge event listeners

--- a/src/hooks/postupdate.ts
+++ b/src/hooks/postupdate.ts
@@ -33,7 +33,9 @@ function suggestAlternatives(): void {
     CliUx.ux.log('- installer: https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-x64.exe');
   } else if (process.platform === 'darwin') {
     if (process.arch === 'arm64') {
-      CliUx.ux.log('- installer: https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-arm64.pkg');
+      CliUx.ux.log(
+        '- installer: https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-arm64.pkg'
+      );
     } else {
       CliUx.ux.log('- installer: https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-x64.pkg');
     }
@@ -56,8 +58,6 @@ const hook: Hook.Update = async function (opts): Promise<void> {
   CliUx.ux.action.start('sfdx-cli: Updating sf');
 
   try {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     const pjson = readJsonSync(path.join(__dirname, '../../package.json')) as { oclif: { dirname: string } };
 
     let dataDirBin;

--- a/src/versions.js
+++ b/src/versions.js
@@ -8,7 +8,6 @@
 // Note: Leave this file as ES5 js for compatibility with earlier Node.js versions
 'use strict';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const pjson = require('../package.json');
 
 /**

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -5,8 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 // the below, there's lots of un-awaited promises for testing
-/* eslint-disable no-unused-expressions*/
-/* eslint-disable @typescript-eslint/require-await*/
 
 import { stubInterface } from '@salesforce/ts-sinon';
 import { getString } from '@salesforce/ts-types';

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -5,8 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 // the below, there's lots of un-awaited promises for testing
-/* eslint-disable no-unused-expressions*/
-/* eslint-disable @typescript-eslint/require-await*/
+
 import { expect } from 'chai';
 import { Env } from '../src/util/env';
 

--- a/test/verifyPluginVersion.test.ts
+++ b/test/verifyPluginVersion.test.ts
@@ -54,21 +54,18 @@ describe('verifyPluginVersion preinstall hook', () => {
 
   it('should not allow the salesforce-alm plugin with tag "41.1.0" to be installed', async () => {
     await testHook('salesforce-alm', '41.1.0');
-    // eslint-disable-next-line no-unused-expressions
     expect(context.error.getCalls().some((call) => getString(call, 'args[0]')?.includes('can only be installed'))).to.be
       .true;
   });
 
   it('should not allow the salesforce-alm plugin with tag "41.1.0" to be installed', async () => {
     await testHook('salesforce-alm', '41.1.0');
-    // eslint-disable-next-line no-unused-expressions
     expect(context.error.getCalls().some((call) => getString(call, 'args[0]')?.includes('can only be installed'))).to.be
       .true;
   });
 
   it('should not allow installation of sfdx-cli as a plugin regardless of the tag', async () => {
     await testHook('sfdx-cli', '');
-    // eslint-disable-next-line no-unused-expressions
     expect(context.error.getCalls().some((call) => getString(call, 'args[0]')?.includes(BANNED_PLUGINS['sfdx-cli']))).to
       .be.true;
   });

--- a/test/versions.test.ts
+++ b/test/versions.test.ts
@@ -5,7 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 // the below, there's lots of un-awaited promises for testing
-/* eslint-disable no-unused-expressions*/
 
 import { assert, expect } from 'chai';
 import * as sinon from 'sinon';


### PR DESCRIPTION
### What does this PR do?
adds `--debug-filter` to be used with --dev-debug to filter output
removes ts-lint/es-lint rules that were no longer being broken

### What issues does this PR fix or reference?
@W-12152987@