### PR TITLE
ci: hide release notes in pr builds

### DIFF
--- a/.github/workflows/makePRforRC.yml
+++ b/.github/workflows/makePRforRC.yml
@@ -22,6 +22,7 @@ jobs:
     if: ${{ !github.event.workflow_run || github.event.workflow_run.conclusion == 'success' }}
     env:
       GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+      SFDX_HIDE_RELEASE_NOTES: true
     runs-on: 'ubuntu-latest'
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
### What does this PR do?
hides the RN from the install scripts via env

### What issues does this PR fix or reference?
[skip-validate-pr]