### PR TITLE
Lookup workflow conclusion

### DIFF
--- a/.github/workflows/releaseFail.yml
+++ b/.github/workflows/releaseFail.yml
@@ -11,10 +11,26 @@ on:
     branches:
       - main
 
+# There seems to be an issue where the workflow_run is sometimes missing from the event
+# For context: "github.event.workflow_run.conclusion"
+# Using a workaround that was found here: https://github.com/community/community/discussions/21090#discussioncomment-3226271
 jobs:
+  get-workflow-conclusion:
+    name: Lookup conclusion of workflow_run event
+    runs-on: ubuntu-latest
+    outputs:
+      conclusion: ${{ fromJson(steps.get_conclusion.outputs.data).conclusion }}
+    steps:
+      - name: Get Workflow Run
+        uses: octokit/request-action@v2.1.0
+        id: get_conclusion
+        with:
+          route: GET /repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
   failure-notify:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    if: ${{ jobs.get-workflow-conclusion.outputs.conclusion == 'failure' }}
     steps:
       - name: Announce Failure
         id: slack
@@ -23,22 +39,24 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.CLI_ALERTS_SLACK_WEBHOOK }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         with:
+          # Payload can be visually tested here: https://app.slack.com/block-kit-builder/T01GST6QY0G#%7B%22blocks%22:%5B%5D%7D
+          # Only copy over the "blocks" array to the Block Kit Builder
           payload: |
             {
-              "text": "${{ github.event.workflow_run.name }} failed: ${{ github.event.workflow_run.repository.name }}",
+              "text": "Workflow \"${{ github.event.workflow_run.name }}\" failed in ${{ github.event.workflow_run.repository.name }}",
               "blocks": [
                 {
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": ":attentioncse: ${{ github.event.workflow_run.name }} failed: ${{ github.event.workflow_run.repository.name }}"
+                    "text": ":bh-alert: Workflow \"${{ github.event.workflow_run.name }}\" failed in ${{ github.event.workflow_run.repository.name }} :bh-alert:"
                   }
                 },
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "repo: ${{ github.event.workflow_run.repository.html_url }}\nworkflow name: ${{ github.event.workflow_run.name }}\njob url: ${{ github.event.workflow_run.html_url }}"
+                    "text": "*Repo:* ${{ github.event.workflow_run.repository.html_url }}\n*Workflow name:* `${{ github.event.workflow_run.name }}`\n*Job url:* ${{ github.event.workflow_run.html_url }}"
                   }
                 }
               ]


### PR DESCRIPTION
### What does this PR do?
The failure notification is not firing on failed CLI releases. There seems to be an issue where the `workflow_run` is sometimes missing from the `event` (`github.event.workflow_run.conclusion`)
Using a workaround that was found here: https://github.com/community/community/discussions/21090#discussioncomment-3226271

Also updates the slack text to match repo's failure notifications.

### What issues does this PR fix or reference?
[@W-12369052@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-12369052)