### PR TITLE
Fix bash substituion

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -86,7 +86,8 @@ jobs:
     steps:
       - id: replace-channel
         run: |
-          S3_NEW_CHANNEL=$(${{ inputs.new-channel }}/latest/stable)
+          NEW_CHANNEL=${{ inputs.new-channel }}
+          S3_NEW_CHANNEL=${NEW_CHANNEL/latest/stable}
           echo "s3-new-channel=$S3_NEW_CHANNEL" >> "$GITHUB_OUTPUT"
 
   # CTC is only needed for promotions to 'latest'
@@ -100,8 +101,8 @@ jobs:
   # See a working example here: https://github.com/iowillhoit/gha-sandbox/blob/main/.github/workflows/needing-an-optional-job-alternate.yml
   ctc-proceed:
     runs-on: ubuntu-latest
-    needs: [ctc-open]
-    if: always()
+    needs: [ctc-open, validate-inputs, get-package-info, build-s3-channel]
+    if: always() && (needs.validate-inputs.result == 'success' && needs.get-package-info.result == 'success' && needs.build-s3-channel.result == 'success')
     steps:
       - run: |
           RESULT=${{ needs.ctc-open.result }}


### PR DESCRIPTION
### What does this PR do?
Two things:
- Fixes bad bash substitution
  - <img width="727" alt="Screenshot 2023-02-16 at 10 43 55 AM" src="https://user-images.githubusercontent.com/1715111/219433492-6f65a10a-3b2f-493e-946e-ff4c1508d936.png">
- Modifies the `if` on `ctc-proceed` to require previous steps to be successful ([because](https://github.com/salesforcecli/sfdx-cli/actions/runs/4196104397))
 


### What issues does this PR fix or reference?
[skip-validate-pr]