### PR TITLE
fix(docker): install deps before running script

### DIFF
--- a/.github/workflows/update-docker-node-version.yml
+++ b/.github/workflows/update-docker-node-version.yml
@@ -17,7 +17,9 @@ jobs:
         with:
           node-version: lts/*
           cache: yarn
-      - run: node ./dockerfiles/update-docker-node-version.js
+      - run: |
+          yarn install
+          node ./dockerfiles/update-docker-node-version.js
       - uses: salesforcecli/github-workflows/.github/actions/gitConfig@main
       # Push changes if 'git status' is not empty
       - run: |


### PR DESCRIPTION
### What does this PR do?
updates docker-update-node workflow to install deps before running node script
Should fix https://github.com/salesforcecli/sfdx-cli/actions/runs/4285406449/jobs/7463665799#step:4:9

### What issues does this PR fix or reference?
@W-0@