### PR TITLE
test: nuts on higher parallelism

### DIFF
--- a/.github/workflows/just-nuts.yml
+++ b/.github/workflows/just-nuts.yml
@@ -18,7 +18,6 @@ on:
 
 jobs:
   basic:
-    if: ${{ !github.event.workflow_run || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
       max-parallel: 6
@@ -28,16 +27,13 @@ jobs:
           - salesforcecli/plugin-alias
           - salesforcecli/plugin-auth
           - salesforcecli/plugin-community
-          # omitted while nuts are too flaky on bulk commands
-          # - salesforcecli/plugin-data
+          - salesforcecli/plugin-data
           - salesforcecli/plugin-limits
           - salesforcecli/plugin-org
           - salesforcecli/plugin-schema
           - salesforcecli/plugin-signups
           - salesforcecli/plugin-user
           - salesforcecli/plugin-packaging
-
-          # private repos
           - salesforcecli/plugin-custom-metadata
     uses: ./.github/workflows/justNut.yml
     with:
@@ -46,7 +42,6 @@ jobs:
       os: ${{matrix.os}}
     secrets: inherit
   source:
-    if: ${{ !github.event.workflow_run || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/just-nuts.yml
+++ b/.github/workflows/just-nuts.yml
@@ -45,7 +45,7 @@ jobs:
       channel-or-version: ${{ inputs.channel-or-version }}
       os: ${{matrix.os}}
     secrets: inherit
-  source-regular:
+  source:
     if: ${{ !github.event.workflow_run || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
@@ -55,21 +55,6 @@ jobs:
           - yarn test:nuts:convert
           - yarn test:nuts:mdapi
           - yarn test:nuts:deploy:metadata
-    uses: ./.github/workflows/justNut.yml
-    with:
-      repository: salesforcecli/plugin-source
-      channel-or-version: ${{ inputs.channel-or-version }}
-      os: ${{matrix.os}}
-      command: ${{matrix.command}}
-    secrets: inherit
-
-  source-big:
-    if: ${{ !github.event.workflow_run || github.event.workflow_run.conclusion == 'success' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-20-8core]
-        command:
           - yarn test:nuts:delete
           - yarn test:nuts:deploy:async
           - yarn test:nuts:deploy:destructive


### PR DESCRIPTION
### What does this PR do?
runs source nuts using higher parallelism change from plugin-source

### What issues does this PR fix or reference?
[skip-validate-pr]

open question:
would this code prevent the tests from running when called from the publish job?  
```
    if: ${{ !github.event.workflow_run || github.event.workflow_run.conclusion == 'success' }}
```