### PR TITLE
chore: remove plugin-alias from just nuts add settings [skip-ci]

### DIFF
--- a/.github/workflows/just-nuts.yml
+++ b/.github/workflows/just-nuts.yml
@@ -24,13 +24,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         repository:
-          - salesforcecli/plugin-alias
           - salesforcecli/plugin-auth
           - salesforcecli/plugin-community
           - salesforcecli/plugin-data
           - salesforcecli/plugin-limits
           - salesforcecli/plugin-org
           - salesforcecli/plugin-schema
+          - salesforcecli/plugin-settings
           - salesforcecli/plugin-signups
           - salesforcecli/plugin-user
           - salesforcecli/plugin-packaging


### PR DESCRIPTION
### What does this PR do?
removes plugin-alias and add plugin-settings to just nuts
add --job 20 to parallel test runs

