### PR TITLE
Trying pr ref for checkout

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -97,7 +97,16 @@ jobs:
     needs: [validate-channel]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout from main if merged
+        uses: actions/checkout@v3
+        if: github.event.pull_request.merged == true
+
+      - name: Checkout from PR if not merged
+        uses: actions/checkout@v3
+        if: github.event.pull_request.merged == false
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Conventional Changelog Action
         id: changelog
         uses: TriPSs/conventional-changelog-action@d360fad3a42feca6462f72c97c165d60a02d4bf2

--- a/.github/workflows/make-pr-for-release.yml
+++ b/.github/workflows/make-pr-for-release.yml
@@ -48,6 +48,8 @@ jobs:
           node-version: lts/*
       - run: npm install -g @salesforce/plugin-release-management --omit=dev
       - uses: salesforcecli/github-workflows/.github/actions/gitConfig@main
+      - name: Fetch all branches
+        run: git fetch
       - run: |
           sf-release cli:release:build \
             --release-channel ${{ inputs.release-channel }} \


### PR DESCRIPTION
### What does this PR do?
We had an issue where a latest-rc patch was pulling in changes from main. I believe that this was because of the `github/checkout` action. this change makes sure we use the PR ref 


### What issues does this PR fix or reference?
