### PR TITLE
chore: remove migrated nuts

### DIFF
--- a/.github/workflows/just-nuts.yml
+++ b/.github/workflows/just-nuts.yml
@@ -45,10 +45,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         command:
-          - yarn test:nuts:convert
           - yarn test:nuts:mdapi
           - yarn test:nuts:deploy:metadata
-          - yarn test:nuts:delete
           - yarn test:nuts:deploy:async
           - yarn test:nuts:deploy:destructive
           - yarn test:nuts:deploy:manifest


### PR DESCRIPTION
What does this PR do?
Removes a nut call to one that migrated to plugin-deploy-retrieve

What issues does this PR fix or reference?
[skip-validate-pr]