### PR TITLE
chore: adjust crons

### DIFF
--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -2,7 +2,7 @@ name: automerge-dependabot
 on:
   workflow_dispatch:
   schedule:
-    - cron: '18 2,5,8,11 * * *'
+    - cron: '18 1,4,7,10 * * *'
 
 jobs:
   automerge:

--- a/.github/workflows/promote-rc-to-latest.yml
+++ b/.github/workflows/promote-rc-to-latest.yml
@@ -3,8 +3,8 @@ name: promote-rc-to-latest
 on:
   workflow_dispatch:
   schedule:
-    # Thursdays 9a central
-    - cron: '0 14 * * 4'
+    # Thursdays 11a central
+    - cron: '0 16 * * 4'
 
 jobs:
   promote:


### PR DESCRIPTION
### What does this PR do?
Adjusting dependabot cron to prevent collisions with `nightly` automerge
Also moves promotion a bit later so that we could get in a quick fix in the morning before promotions

### What issues does this PR fix or reference?
[skip-validate-pr]