### PR TITLE
Add patch notification

### DIFF
--- a/.github/workflows/create-cli-release.yml
+++ b/.github/workflows/create-cli-release.yml
@@ -124,7 +124,7 @@ jobs:
       channel: ${{ needs.get-channel.outputs.channel }}
     secrets: inherit
 
-  announce-rc-release-to-slack:
+  announce-cli-patch-in-slack:
     # Do not announce prereleases or nightlies
     # https://docs.github.com/en/actions/learn-github-actions/expressions#contains
     if: ${{ contains(fromJSON('["latest", "latest-rc"]'), needs.get-channel.outputs.channel ) }}
@@ -139,18 +139,21 @@ jobs:
       - pack-upload-mac
       - rename-mac-pkg
     steps:
-      - name: Announce RC Workflow
-        id: slack
+      - name: Announce patch in Slack
         uses: slackapi/slack-github-action@v1.21.0
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_RC_ANNOUNCEMENT_WORKFLOW_WEBHOOK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         with:
-          # This data can be any valid JSON from a previous step in the GitHub Action
           payload: |
             {
-              "cli": "sfdx",
-              "npm-package": "sfdx-cli",
-              "version": "${{ github.event.release.tag_name }}"
+              "blocks": [{
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": ":bandaid-4506: `sfdx-cli@${{ needs.get-channel.outputs.channel }}` has been patched in version `${{ github.event.release.tag_name }}` :bandaid-4506:\nPlease ensure you are running the newest version of `sfdx`"
+                }
+              }]
             }
 
   run-just-nuts:


### PR DESCRIPTION
What does this PR do?
Updates the slack post in create-cli-release. Now that we promote nightlies, this will only ever fire for patches to `latest` and `latest-rc`.
Example message:
https://app.slack.com/block-kit-builder/T01GST6QY0G#%7B%22blocks%22:%5B%7B%22type%22:%22section%22,%22text%22:%7B%22type%22:%22mrkdwn%22,%22text%22:%22:bandaid-4506:%20%60sf@latest-rc%60%20has%20been%20patched%20in%20version%20%601.74.1%60%20:bandaid-4506:%5CnPlease%20ensure%20you%20are%20running%20the%20newest%20version%20of%20%60sf%60%22%7D%7D%5D%7D

What issues does this PR fix or reference?
[@W-12949193@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-12949193)