### PR TITLE
Get highest 1.x of sf

### DIFF
--- a/scripts/include-sf.js
+++ b/scripts/include-sf.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 // Get the latest version that starts with 1 (we do not want to ever bundle version 2 of @salesforce/cli)
 // We cannot use @salesforce/cli@^1 because that will not get versions higher than what is tagged as "latest"
 const versions = JSON.parse(shelljs.exec('npm view @salesforce/cli versions --json').stdout.trim());
-const latestVersion = versions.reverse().find((v) => v.startsWith('1.'));
+const latestVersion = versions.reverse().find((v) => v.startsWith('1.') && !v.includes('-'));
 shelljs.exec(`npm install @salesforce/cli@${latestVersion} -g`);
 
 const npmGlobalInstallPath = shelljs.exec('npm list -g --depth 0 | head -1').stdout.trim();

--- a/scripts/include-sf.js
+++ b/scripts/include-sf.js
@@ -4,7 +4,11 @@ const path = require('path');
 const shelljs = require('shelljs');
 const fs = require('fs');
 
-shelljs.exec('npm install @salesforce/cli@^1 -g');
+// Get the latest version that starts with 1 (we do not want to ever bundle version 2 of @salesforce/cli)
+// We cannot use @salesforce/cli@^1 because that will not get versions higher than what is tagged as "latest"
+const versions = JSON.parse(shelljs.exec('npm view @salesforce/cli versions --json').stdout.trim());
+const latestVersion = versions.reverse().find((v) => v.startsWith('1.'));
+shelljs.exec(`npm install @salesforce/cli@${latestVersion} -g`);
 
 const npmGlobalInstallPath = shelljs.exec('npm list -g --depth 0 | head -1').stdout.trim();
 const sfGlobalPath = path.join(npmGlobalInstallPath, 'node_modules', '@salesforce', 'cli');


### PR DESCRIPTION
### What does this PR do?
`npm install @salesforce/cli@^1` will not install a version higher than what is tagged as `latest` in npm. 
This will list all tags from `npm` and find the **newest** `1.x` version

### What issues does this PR fix or reference?
[skip-validate-pr]