### PR TITLE
Better sf bundle lookup

### DIFF
--- a/scripts/determine-sf-version.js
+++ b/scripts/determine-sf-version.js
@@ -7,14 +7,17 @@ const getVersion = () => {
   // Get all npm dist-tags for sfdx-cli
   const distTags = JSON.parse(shelljs.exec('npm view sfdx-cli dist-tags --json', { silent: true }).stdout.trim());
 
-  // Find the dist-tag that matches the sfdx-cli package.json version
-  const distTag = Object.entries(distTags).find(([, version]) => version === sfdxVersion)[0];
+  // Attempt to find a dist-tag that matches the sfdx-cli package.json version
+  const distTag = Object.entries(distTags).find(([, version]) => version === sfdxVersion);
 
-  // Now get the version of @salesforce/cli for the same dist-tag
-  let sfVersion = shelljs.exec(`npm view @salesforce/cli@${distTag} version`, { silent: true }).stdout.trim();
+  // If we found a dist-tag, get the version of @salesforce/cli for the same dist-tag
+  // Note: the --silent flag causes the command to return an empty string if the version is not found
+  let sfVersion = distTag?.[0]
+    ? shelljs.exec(`npm view @salesforce/cli@${distTag[0]} version --silent`, { silent: true }).stdout.trim()
+    : undefined;
 
-  // Make sure that the version of @salesforce/cli does not start with 2
-  if (sfVersion.startsWith('2')) {
+  // Make sure that sfVersion is set and it does not start with 2
+  if (!sfVersion || sfVersion.startsWith('2')) {
     // If it does, get the latest version that starts with 1 (we do not want to ever bundle version 2 of @salesforce/cli)
     // We cannot use @salesforce/cli@^1 because that will not get versions higher than what is tagged as "latest"
     const versions = JSON.parse(


### PR DESCRIPTION
### What does this PR do?
Handles the version to bundle better when a sfdx dist-tag is not found.
Handles if a dist-tag does not exist on `sf`

If either of these situations are seen, we fall back to "highest 1.x"

TESTING
- pull branch
- modify the package.json version 
- run `node -e 'require("./scripts/determine-sf-version").getVersion()'`
- Values to try
  - `7.177.0-dev.4` (dev-rc does not exist on sf)
  - `7.1000.0` (does not exist in sfdx-cli's current dist-tags)
  - `7.201.6` (current sfdx-cli latest-rc, this should return latest-rc version of sf)

### What issues does this PR fix or reference?
[@W-13197302@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-13197302)