### PR TITLE
chore: yarn install

### DIFF
--- a/.github/workflows/build-docker-full.yml
+++ b/.github/workflows/build-docker-full.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
+      - name: Yarn install
+        uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
+
       - name: Log in to Docker Hub
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:


### PR DESCRIPTION
### What does this PR do?
Runs a yarn install so that we can use `shelljs` in the determine-sf-version script

### What issues does this PR fix or reference?
[@W-13197302@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-13197302)