### PR TITLE
chore: remove ts-types from resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -238,8 +238,7 @@
     "@salesforce/schemas": "1.5.1",
     "@salesforce/source-deploy-retrieve": "9.2.3",
     "@salesforce/source-tracking": "4.2.1",
-    "@salesforce/templates": "58.0.0",
-    "@salesforce/ts-types": "2.0.3"
+    "@salesforce/templates": "58.0.0"
   },
   "scripts": {
     "build": "wireit",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2022,12 +2022,19 @@
     sinon "^5.1.1"
     tslib "^2.5.3"
 
-"@salesforce/ts-types@2.0.3", "@salesforce/ts-types@^1.7.1", "@salesforce/ts-types@^1.7.2", "@salesforce/ts-types@^1.7.3", "@salesforce/ts-types@^2.0.1", "@salesforce/ts-types@^2.0.2", "@salesforce/ts-types@^2.0.3":
+"@salesforce/ts-types@2.0.3", "@salesforce/ts-types@^2.0.1", "@salesforce/ts-types@^2.0.2", "@salesforce/ts-types@^2.0.3":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-2.0.3.tgz#ae944fce71e3fc4c154592f3ee56496d2b6c9d5e"
   integrity sha512-PWxNB1GhlX045GN6TQ8HRvJudVpm3SE/v3520itBSCXSM+iBSQ09YIxT6EO2XXGwofQBXlQqN5hsXVI5+uFazg==
   dependencies:
     tslib "^2.5.3"
+
+"@salesforce/ts-types@^1.7.1", "@salesforce/ts-types@^1.7.2", "@salesforce/ts-types@^1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-1.7.3.tgz#89b79ff0aaa55fea9f2de0afa8e515be3e17d0d8"
+  integrity sha512-jpmekGqZ7tpHRJwf1rF0yBJ/IMC5mOrryNi4HZkKuNQn8RF97WpynmL8Om04mLTCESvCiif3y7NWfIcxtID2Gw==
+  dependencies:
+    tslib "^2.5.0"
 
 "@sigstore/protobuf-specs@^0.1.0":
   version "0.1.0"


### PR DESCRIPTION
### What does this PR do?
Removes `@salesforce/ts-types` from `resolutions`. It is already in pinnedDeps

### What issues does this PR fix or reference?
[skip-validate-pr]