### PR TITLE
Remove change logs

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -68,22 +68,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
-
-      - name: Conventional Changelog Action
-        id: changelog
-        uses: TriPSs/conventional-changelog-action@9962c3267b32873dbc552a38a8397194361e1101
-        # overriding some of the basic behaviors to just get the changelog
-        with:
-          git-user-name: svc-cli-bot
-          git-user-email: svc_cli_bot@salesforce.com
-          github-token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
-          output-file: false
-          # always do the release, even if there are no semantic commits
-          skip-on-empty: false
-          # pjson version was already updated by the "cli:release:build" script, so don't base behavior on these commits
-          skip-version-file: true
-          # avoids the default `v` so all the later actions don't have to remove it
-          tag-prefix: ''
       - uses: notiz-dev/github-action-json-property@2192e246737701f108a4571462b76c75e7376216
         id: packageVersion
         with:
@@ -100,6 +84,3 @@ jobs:
           # This channel value is read from the Github Release body to determine the channel. Be cautious editing
           body: |
             !! Release as ${{ needs.validate-channel.outputs.channel }} !!
-
-            Change log:
-            ${{ steps.changelog.outputs.clean_changelog }}


### PR DESCRIPTION
### What does this PR do?
The CLIs do not use conventional-commits to bump the version number in the package.json. Also, the changelogs are not working on the CLIs (see below), because of this I don't think this GHA step is needed. 

--- 
## More info for a future ticket:
Since we use `skip-version-file: true` with `conventional-changelog-action` on the CLIs, the versions are looked up using `git` . It finds the last tag, and then uses the `releaseType` to determine how to bump it. [Here is an example](https://github.com/salesforcecli/sfdx-cli/actions/runs/5285638613/jobs/9564315511#step:3:1036) of this being incorrect. This is the `create-github-release` run for `7.207.0` where it chose `7.206.7` instead.
<img width="964" alt="Screenshot 2023-06-27 at 12 13 11 PM" src="https://github.com/salesforcecli/sfdx-cli/assets/1715111/e34615a5-efa9-4c50-85bf-a55218bf3538">

Things to consider
* Switch to use conventional commits on the CLI
    * Have the `sf-release cli build release` script "tag" the commit message (`fix:` or `feat:`) according to the `--patch` flag ([source](https://github.com/salesforcecli/sfdx-cli/releases/tag/7.191.0))
    * How can we get all dependency bumps to show up in the changelog?
        * Add a `fix:` commit for each dep bump: `fix: bump plugin-source from 1.2.3 to 1.2.4`
            * Is there a way to use a squash commit to get the same information?
        * Bonus, we could reenable the `changelog.md` file for searching when a version of a plugin was included a cli release.
* The release body used to have more useful info prior to nightlies ([example](https://github.com/salesforcecli/sfdx-cli/releases/tag/7.191.0))

### What issues does this PR fix or reference?
[@W-13660199@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-13660199)